### PR TITLE
Přidání Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,8 @@ description: > # this means to ignore newlines until "baseurl:"
   Google search results) and in your feed.xml site description.
 baseurl: "/learn-jekyll" # the subpath of your site, e.g. /blog
 url: "https://jan-martinek.github.io/learn-jekyll" # the base hostname & protocol for your site, e.g. http://example.com
-
+# Google services
+google_analytics: UA-98322490-1
 # Build settings
 markdown: kramdown
 gems:

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,10 @@
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{ site.google_analytics }}', 'auto');
+  ga('send', 'pageview');
+
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,9 @@
 	<meta charset="utf-8">
 	<title>{{ site.title }}</title>
 	<link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/style.css">
+	{% if jekyll.environment == 'production' %}
+	{% include analytics.html %}
+	{% endif %}
 	
 </head>
 <body>


### PR DESCRIPTION
V souboru _config.yml jsem založil novou proměnnou google_analytics a
vložil jsem do ní přidělený ID Tracking od Googlu.
Ve složce _includes jsem vytvořil nový soubor analytics.html, který v
sobě obsahuje skript pro sledování stránky pro analytické účely. Využil
jsem zde proměnnou site.google_analytics.
Do strány default.html od její hlavičky jsem vložil skritp a přidal
podmínku, že musí jít o produkční přístup na stránku (nelokální host),
aby nedocházelo ke zkreslování statistik.